### PR TITLE
feat: show message timestamp next to the top message that is grouped

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+tab_width = 2
+indent_size = 2
+trim_trailing_whitespace = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,6 +5432,7 @@ dependencies = [
 name = "scope"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "dotenv",
  "env_logger",
  "gpui",
@@ -5450,6 +5451,7 @@ dependencies = [
 name = "scope-backend-discord"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "gpui",
  "scope-chat",
  "serenity",
@@ -5460,6 +5462,7 @@ dependencies = [
 name = "scope-chat"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "gpui",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = [
 ]
 
 [workspace.dependencies]
+chrono = "0.4.38"

--- a/src/chat/Cargo.toml
+++ b/src/chat/Cargo.toml
@@ -9,3 +9,4 @@ gpui = { git = "https://github.com/huacnlee/zed.git", branch = "export-platform-
   "font-kit",
 ] }
 tokio = "1.41.1"
+chrono.workspace = true

--- a/src/chat/src/message.rs
+++ b/src/chat/src/message.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use gpui::Element;
 
 pub trait Message: Clone {
@@ -6,6 +7,7 @@ pub trait Message: Clone {
   fn get_identifier(&self) -> String;
   fn get_nonce(&self) -> Option<&String>;
   fn should_group(&self, previous: &Self) -> bool;
+  fn get_timestamp(&self) -> Option<DateTime<Utc>>;
 }
 
 pub trait MessageAuthor: PartialEq + Eq {

--- a/src/discord/Cargo.toml
+++ b/src/discord/Cargo.toml
@@ -11,3 +11,4 @@ gpui = { git = "https://github.com/huacnlee/zed.git", branch = "export-platform-
 scope-chat = { version = "0.1.0", path = "../chat" }
 serenity = { git = "https://github.com/scopeclient/serenity", version = "0.13.0" }
 tokio = "1.41.1"
+chrono.workspace = true

--- a/src/discord/src/message/mod.rs
+++ b/src/discord/src/message/mod.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use author::DiscordMessageAuthor;
 use content::DiscordMessageContent;
 use gpui::{Element, IntoElement};
@@ -38,5 +39,11 @@ impl Message for DiscordMessage {
     const MAX_DISCORD_MESSAGE_GAP_SECS_FOR_GROUP: i64 = 5 * 60;
 
     self.creation_time.signed_duration_since(*previous.creation_time).num_seconds() <= MAX_DISCORD_MESSAGE_GAP_SECS_FOR_GROUP
+  }
+
+  fn get_timestamp(&self) -> Option<DateTime<Utc>> {
+    let ts = self.creation_time.timestamp_millis();
+
+    DateTime::from_timestamp_millis(ts)
   }
 }

--- a/src/ui/Cargo.toml
+++ b/src/ui/Cargo.toml
@@ -28,6 +28,7 @@ components = { package = "ui", git = "https://github.com/longbridgeapp/gpui-comp
 log = "0.4.22"
 random-string = "1.1.0"
 rust-embed = "8.5.0"
+chrono.workspace = true
 
 [features]
 default = ["gpui/x11"]

--- a/src/ui/src/channel/message.rs
+++ b/src/ui/src/channel/message.rs
@@ -1,4 +1,6 @@
 use gpui::{div, img, rgb, Element, IntoElement, ParentElement, Styled};
+use gpui::prelude::FluentBuilder;
+use chrono::Local;
 use scope_chat::message::{Message, MessageAuthor};
 
 #[derive(Clone)]
@@ -24,7 +26,7 @@ impl<M: Message> MessageGroup<M> {
     self.contents.push(message);
   }
 
-  pub fn contents(&self) -> impl IntoIterator<Item = impl Element + '_> {
+  pub fn contents(&self) -> impl IntoIterator<Item=impl Element + '_> {
     self.contents.iter().map(|v| v.get_content())
   }
 
@@ -71,7 +73,21 @@ pub fn message<M: Message>(message: MessageGroup<M>) -> impl IntoElement {
         .flex_col()
         // enabling this, and thus enabling ellipsis causes a consistent panic!?
         // .child(div().text_ellipsis().min_w_0().child(message.get_author().get_display_name()))
-        .child(div().min_w_0().child(message.get_author().get_display_name()))
+        .child(
+          div()
+            .min_w_0()
+            .flex()
+            .gap_2()
+            .child(message.get_author().get_display_name())
+            .when_some(message.last().get_timestamp(), |d, ts| {
+              d.child(
+                div()
+                  .min_w_0()
+                  .text_color(rgb(0xAFBAC7))
+                  .text_sm()
+                  .child(ts.with_timezone(&Local).format("%I:%M %p").to_string()))
+            })
+        )
         .children(message.contents()),
     )
 }


### PR DESCRIPTION
Hello Scope Team,

Awesome project you got here! I'd love to contribute more if my time allows! Also really appreciate the switch to gpui!

This is a rather small PR, I know. But I just wanted to get feedback about project style guides, since there is currently no documentation about this. 

So, if there is anything you don't like in here, feel free to criticize me! It can only help.

Also some small note: Should the last message time or the oldest message time in a group be displayed? The native discord client does first message and shows subsequent message timestamp on hover, the current implementation uses the last message and no hover yet.

Thanks for reading and considering pulling.

Greetings, 
Christian Bergschneider